### PR TITLE
add callFunction method to lua class

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Features
 - Run lua directly from a string or a text file.
 - Push any Variant as a global.
 - Expose GDScript functions to lua with a return value and up to 5 arguments.
+- Call lua functions from GDScript.
 - By default the lua print function is set to print to the GDEditor console. This can be changed by exposing your own print function as it will overwrite the existing one.
 
 TODO
@@ -97,6 +98,18 @@ func luaAdd(a, b):
 func _ready():
 	lua.exposeFunction(self, "luaAdd", "add")
 	lua.doString(self, "print(add(2, 4))", String())
+```
+<br />
+
+**Calling a lua function from GDScript:**
+```
+extends Node2D
+
+onready var lua = Lua.new()
+
+func _ready():
+	lua.doFile(self, "user://luaFile.lua", String())
+	lua.callFunction(self, "set_colours", ["red", "blue"])
 ```
 <br />
 

--- a/lua.cpp
+++ b/lua.cpp
@@ -27,6 +27,7 @@ void Lua::_bind_methods(){
     ClassDB::bind_method(D_METHOD("doString", "NodeObject", "Code", "Callback=String()"), &Lua::doString);
     ClassDB::bind_method(D_METHOD("pushVariant", "var"),&Lua::pushGlobalVariant);
     ClassDB::bind_method(D_METHOD("exposeFunction", "NodeObject", "GDFunction", "LuaFunctionName"),&Lua::exposeFunction);
+    ClassDB::bind_method(D_METHOD("callFunction", "NodeObject", "LuaFunctionName", "Args"), &Lua::callFunction);
 }
 
 // expose a GDScript function to lua
@@ -75,6 +76,23 @@ void Lua::exposeFunction(Object *instance, String function, String name){
   // Setting the global name for the function in lua
   lua_setglobal(state, fname);
   
+}
+
+// call a Lua function from GDScript
+void Lua::callFunction(Object *instance, String name, Array args) {
+    std::wstring temp = name.c_str();
+    std::string fname(temp.begin(), temp.end());
+
+    // put global function name on stack
+    lua_getglobal(state, fname.c_str());
+
+    // push args
+    for (int i = 0; i < args.size(); ++i) {
+        pushVariant(args[i]);
+    }
+
+    // call function (for now, lua functions cannot return values to gdscript)
+    lua_call(state, args.size(), 0);
 }
 
 void Lua::setThreaded(bool thread){

--- a/lua.h
+++ b/lua.h
@@ -20,6 +20,7 @@ public:
   ~Lua();
   
   void exposeFunction(Object *instance, String function, String name);
+  void callFunction(Object *instance, String name, Array args);
   void doFile(Object *instance, String fileName, String callback = String());
   void doString(Object *instance, String code, String callback = String());
   void setThreaded(bool thread);


### PR DESCRIPTION
this allows a GDScript program to call global functions on a user's lua script. this is useful for a variety of reasons, for me it's the ability to create a "hooks" system like this:

```lua
function on_player_spawned(name, id)
    print("player has been spawned with name: "..name.." and id: "..id)
end

add_hook("player_spawned", "on_player_spawned")
```

and then in gdscript:

```gdscript
func add_hook(hook_name: String, function_name: String) -> void:
    hooks[hook_name].append(function_name)

func spawn_player(name: String, id: int) -> void:
    for hook in hooks["player_spawned"]:
        lua.callFunction(self, hook, [name, id])
```