### PR TITLE
Vector2,Vector3 and Color types passed as userdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,21 @@ Features
 - Expose GDScript functions to lua with a return value and up to 5 arguments.
 - Call lua functions from GDScript.
 - By default the lua print function is set to print to the GDEditor console. This can be changed by exposing your own print function as it will overwrite the existing one.
+- Basic types are passed as userdata (currently: Vector2, Vector3 and Color) with a useful metatable. This means you can do things like:  
+```lua
+local v1 = Vector2(1,2)
+local v2 = Vector2(100,100)
+print( v2.x ) -- "100"
+print( v1+v2 ) -- "(101,102)"
+change_my_sprite_color( Color(1,0,0,1) ) -- if "change_my_sprite_color" was exposed, in GDScript it will receive a Color variant.
+```
 
 TODO
 -----
 - Add support to kill individual lua threads.
 - Add option to load specific lua librarys.
+- Methods for userdata types, i.e. `.length()` for Vector2
+- Object type passed as userdata? This probably should be optional. User should be careful with reference being freed
 
 Compiling
 ------------

--- a/lua.h
+++ b/lua.h
@@ -5,7 +5,6 @@
 #include "core/bind/core_bind.h"
 
 #include <lua.hpp>
-#include <map>
 #include <string>
 #include <thread>
 
@@ -42,6 +41,13 @@ public:
 private:
   lua_State *state;
   bool threaded;
+
+private:
+  void exposeConstructors( lua_State*ls );
+  void createVector2Metatable( lua_State* ls );
+  void createVector3Metatable( lua_State* ls );
+  void createColorMetatable( lua_State* ls );
+
 };
 
 #endif


### PR DESCRIPTION
This PR makes GD Variants with types VECTOR2, VECTOR3 or COLOR to be pushed as full userdatas. Since these types aren't referenced, I don't think this can lead to any problem (they are `memcpy`'ed)

```
    void* userdata = (Variant*)lua_newuserdata( state , sizeof(Variant) );
    memcpy( userdata , (void*)&var , sizeof(Variant) );
```

- These userdatas have a basic metatable, with the following metamethods defined:

```
__add
__sub
__mul
__div
__index
__newindex
```
So basic operations over Vector2/Vector3/Color can be more simple:
```
local v1 = Vector2( 0.5 , 100 )
local v2 = Vector2( 100 , 0.5 )
print( v1 * v2 ) -- prints "(50,50)"
```

- It also exposes a constructor for these types
```
local v2 = Vector2( 100 , 100 )
local v3 = Vector3( 100 , 100 , 200 )
local c = Color( 1 , 0 , 0 , 0.5 )
```

- Print function is a little more sophisticated (and properly prints these userdata variants)
- Is there a problem to exposedFunctions always return a value? If in GDscript they don't return anything, in Lua it will appear as a nil value. To pass nil values can be useful (before wasn't able to push GD Null values)