### PR TITLE
Optional protected call for callFunction & fixing iterate over table

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ onready var lua = Lua.new()
 
 func _ready():
 	lua.doFile(self, "user://luaFile.lua", String())
-	lua.callFunction(self, "set_colours", ["red", "blue"])
+	if( lua.luaFunctionExists("set_colours") ):
+		lua.callFunction( "set_colours", ["red", "blue"])
 ```
 <br />
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ extends Node2D
 onready var lua = Lua.new()
 
 func _ready():
-	# The third option is to pass a error call back function. passing String() like this will disregard it
-	lua.doString(self, "for i=1,10,1 do print('Hello lua!') end", String())
+	lua.doString("for i=1,10,1 do print('Hello lua!') end")
 ```
 <br />
 
@@ -79,7 +78,7 @@ extends Node2D
 onready var lua = Lua.new()
 
 func _ready():
-	lua.doFile(self, "user://luaFile.lua", String())
+	lua.doFile("user://luaFile.lua")
 ```
 <br />
 
@@ -92,7 +91,7 @@ var test = "Hello lua!"
 
 func _ready():
 	lua.pushVariant(test, "str")
-	lua.doString(self, "print(str)", String())
+	lua.doString("print(str)")
 ```
 <br />
 
@@ -107,7 +106,7 @@ func luaAdd(a, b):
 
 func _ready():
 	lua.exposeFunction(self, "luaAdd", "add")
-	lua.doString(self, "print(add(2, 4))", String())
+	lua.doString("print(add(2, 4))")
 ```
 <br />
 
@@ -118,7 +117,7 @@ extends Node2D
 onready var lua = Lua.new()
 
 func _ready():
-	lua.doFile(self, "user://luaFile.lua", String())
+	lua.doFile("user://luaFile.lua")
 	if( lua.luaFunctionExists("set_colours") ):
 		lua.callFunction( "set_colours", ["red", "blue"])
 ```
@@ -134,7 +133,7 @@ func luaCallBack(err):
 	print(err)
 
 func _ready():
-	lua.doString(self, "print(This wont work)", "luaCallBack")
+	lua.doString("print(This wont work)", true , self, "luaCallBack")
 ```
 <br />
 
@@ -147,7 +146,7 @@ onready var lua = Lua.new()
 
 func _ready():
 	lua.setThreaded(false)
-	lua.doString(self, "while true do print("The entire game will freeze") end", String())
+	lua.doString("while true do print("The entire game will freeze") end" )
 ```
 <br />
 
@@ -159,7 +158,7 @@ onready var lua = Lua.new()
 
 
 func _ready():
-	lua.doString(self, "while true do pass end", String())
+	lua.doString("while true do pass end")
 	lua.killAll()
 ```
 Contributing And Feature Requests

--- a/config.py
+++ b/config.py
@@ -4,3 +4,11 @@ def can_build(env, platform):
 def configure(env):
         if env.msvc:
                 env.Append(LINKFLAGS='liblua.lib')
+
+def get_doc_classes():
+    return [
+        "Lua",
+    ]
+
+def get_doc_path():
+    return "docs"

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="Lua" inherits="Reference" version="3.2">
+	<brief_description>
+	</brief_description>
+	<description>
+		It is recommended to always use [code]ProtectedCall=true[/code], otherwise the engine will crash if a error happens. [code]CallbackCaller[/code] and [code]Callback[/code] can be defined to handle the error message instead printing them to the console. 
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="callFunction">
+			<return type="void">
+			</return>
+			<argument index="0" name="LuaFunctionName" type="String">
+			</argument>
+			<argument index="1" name="Args" type="Array">
+			</argument>
+			<argument index="2" name="ProtectedCall" type="bool" default="true">
+			</argument>
+			<argument index="3" name="CallbackCaller" type="Object" default="null">
+			</argument>
+			<argument index="4" name="Callback" type="String" default="&quot;&quot;">
+			</argument>
+			<description>
+				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with [code]doFile()[/code] or [code]doString()[/code].
+				You may want to check if the function actually exists with [code]luaFunctionExists(LuaFunctionName)[/code].
+				Currently, getting returned values from this function is not available. 
+			</description>
+		</method>
+		<method name="doFile">
+			<return type="void">
+			</return>
+			<argument index="0" name="File" type="String">
+			</argument>
+			<argument index="1" name="ProtectedCall" type="bool" default="true">
+			</argument>
+			<argument index="2" name="CallbackCaller" type="Object" default="null">
+			</argument>
+			<argument index="3" name="Callback" type="String" default="&quot;&quot;">
+			</argument>
+			<description>
+				Loads a file as a string and calls [code]doString[/code] with it.
+			</description>
+		</method>
+		<method name="doString">
+			<return type="void">
+			</return>
+			<argument index="0" name="Code" type="String">
+			</argument>
+			<argument index="1" name="ProtectedCall" type="bool" default="true">
+			</argument>
+			<argument index="2" name="CallbackCaller" type="Object" default="null">
+			</argument>
+			<argument index="3" name="Callback" type="String" default="&quot;&quot;">
+			</argument>
+			<description>
+				Executes [code]Code[/code] as a piece of Lua code.
+			</description>
+		</method>
+		<method name="exposeFunction">
+			<return type="void">
+			</return>
+			<argument index="0" name="NodeObject" type="Object">
+			</argument>
+			<argument index="1" name="GDFunction" type="String">
+			</argument>
+			<argument index="2" name="LuaFunctionName" type="String">
+			</argument>
+			<description>
+				Defines a lua function with name [code]LuaFunctionName[/code]. When Lua code calls it, it will call the [code]GDFunction[/code] method of [code]NodeObject[/code], so make sure the object still exists at this moment.
+			</description>
+		</method>
+		<method name="killAll">
+			<return type="void">
+			</return>
+			<description>
+				Kills all current lua threads in execution.
+			</description>
+		</method>
+		<method name="luaFunctionExists">
+			<return type="bool">
+			</return>
+			<argument index="0" name="LuaFunctionName" type="String">
+			</argument>
+			<description>
+				Returns [code]true[/code] only if [code]LuaFunctionName[/code] is defined in current Lua's state as a function.
+			</description>
+		</method>
+		<method name="pushVariant">
+			<return type="bool">
+			</return>
+			<argument index="0" name="var" type="Variant">
+			</argument>
+			<argument index="1" name="arg1" type="String">
+			</argument>
+			<description>
+			</description>
+		</method>
+		<method name="setThreaded">
+			<return type="void">
+			</return>
+			<argument index="0" name="bool" type="bool">
+			</argument>
+			<description>
+				Set the Lua calls to run on a separated thread. !!! Thread mode is the default !!! 
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/lua.h
+++ b/lua.h
@@ -21,12 +21,12 @@ public:
   void exposeFunction(Object *instance, String function, String name );
   void callFunction( String function_name, Array args, bool protected_call = true , Object* CallbackCaller = nullptr , String callback = String() );
   bool luaFunctionExists(String function_name);
-  void doFile(Object *instance, String fileName, String callback = String());
-  void doString(Object *instance, String code, String callback = String());
+  void doFile( String fileName, bool protected_call = true , Object* CallbackCaller = nullptr , String callback = String() );
+  void doString( String code, bool protected_call = true , Object* CallbackCaller = nullptr , String callback = String() );
   void setThreaded(bool thread);
   void killAll();
 
-  static void runLua(Object *instance, String code, String callback, lua_State *L);
+  static void runLua( lua_State *L , String code, bool protected_call , Object* CallbackCaller , String callback );
 
   bool pushVariant(Variant var);
   bool pushGlobalVariant(Variant var, String name);
@@ -44,10 +44,12 @@ private:
   bool threaded;
 
 private:
-  void exposeConstructors( lua_State*ls );
-  void createVector2Metatable( lua_State* ls );
-  void createVector3Metatable( lua_State* ls );
-  void createColorMetatable( lua_State* ls );
+  void exposeConstructors(  );
+  void createVector2Metatable(  );
+  void createVector3Metatable(  );
+  void createColorMetatable(  );
+
+  static void handleError( lua_State *L , int lua_error );
 
 };
 

--- a/lua.h
+++ b/lua.h
@@ -18,8 +18,9 @@ public:
   Lua();
   ~Lua();
   
-  void exposeFunction(Object *instance, String function, String name);
-  void callFunction(Object *instance, String name, Array args);
+  void exposeFunction(Object *instance, String function, String name );
+  void callFunction( String function_name, Array args, bool protected_call = true , Object* CallbackCaller = nullptr , String callback = String() );
+  bool luaFunctionExists(String function_name);
   void doFile(Object *instance, String fileName, String callback = String());
   void doString(Object *instance, String code, String callback = String());
   void setThreaded(bool thread);


### PR DESCRIPTION
- This PR solves a problem with `Lua::getVariant(int index)`. When passing a relative index (index<0), the proper way to iterate with `lua_next()` is indeed using `index-1`, but when index>0, this should remain only `index`. This was crashing my project.

- Also, it gives a proper way to call lua functions from GDScript. Now we could check beforehand if the function actually exists, and we can optionally set it as a protected call. The arguments order were moved. Before, the first parameter `Object*` doesn't had any utility. I propose to use this same pattern of the same last 3 optional parameters ( bool protected_call , Object* callback_caller , String callback ) in doFile and doString as well, what do you think? To call functions outside protected mode could maybe be more performant, useful when targeting release.