### PR TITLE
Callables as userdata

### DIFF
--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -3,7 +3,7 @@
 	<brief_description>
 	</brief_description>
 	<description>
-		Execute Lua code as runtime and make your own API.
+		Execute Lua code at runtime and make your own API.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -17,11 +17,11 @@
 			</argument>
 			<description>
 				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua.
-				You may want to check if the function actually exists with [code]lua_function_exists(LuaFunctionName)[/code].
+				You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code].
 				This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null. 
 			</description>
 		</method>
-		<method name="load_file">
+		<method name="do_file">
 			<return type="void">
 			</return>
 			<argument index="0" name="FilePath" type="String">
@@ -30,33 +30,15 @@
 				Loads a file with luaL_laodfile() passing its absolute path.
 			</description>
 		</method>
-		<method name="load_string">
+		<method name="do_string">
 			<return type="void">
 			</return>
 			<argument index="0" name="Code" type="String">
 			</argument>
-			<argument index="1" name="ProtectedCall" type="bool" default="true">
-			</argument>
-			<argument index="2" name="CallbackCaller" type="Object" default="null">
-			</argument>
-			<argument index="3" name="Callback" type="String" default="&quot;&quot;">
-			</argument>
-			<description>
-				loas a string with luaL_loadstring()
+				loas a string with luaL_loadstring() and executes the top of the stack
 			</description>
 		</method>
-		<method name="expose_function">
-			<return type="void">
-			</return>
-			<argument index="0" name="function" type="Callable">
-			</argument>
-			<argument index="2" name="LuaFunctionName" type="String">
-			</argument>
-			<description>
-				TODO
-			</description>
-		</method>
-		<method name="lua_function_exists">
+		<method name="function_exists">
 			<return type="bool">
 			</return>
 			<argument index="0" name="LuaFunctionName" type="String">
@@ -82,7 +64,7 @@
 			<argument index="0" name="Name" type="String">
 			</argument>
 			<description>
-			Will pull a copy of a glboal Variant from lua to GDScript.
+			Will pull a copy of a glboal Variant from lua.
 			</description>
 		</method>
 	</methods>

--- a/lua.h
+++ b/lua.h
@@ -3,8 +3,8 @@
 
 #include "core/object/ref_counted.h"
 #include "core/core_bind.h"
-
 #include "luasrc/lua.hpp"
+
 #include <string>
 
 class Lua : public RefCounted {
@@ -19,7 +19,7 @@ public:
   void doFile(String fileName);
   void doString(String code);
   void bindLibs(Array libs);
-  bool pushVariant(Variant var);
+  bool pushVariant(Variant var) const;
   void exposeFunction(Callable func, String name); 
   void setErrorHandler(Callable errorHandler);
   void exposeObjectConstructor(Object* obj, String name);
@@ -27,22 +27,22 @@ public:
   bool pushGlobalVariant(Variant var, String name);
   bool luaFunctionExists(String function_name);
   
-  Variant getVariant(int index = -1);
+  Variant getVariant(int index = -1) const;
   Variant pullVariant(String name);
   Variant callFunction(String function_name, Array args );
-
-  Callable getCallable(int index);
 
   // Lua functions
   static int luaPrint(lua_State* state);
   static int luaExposedFuncCall(lua_State* state);
   static int luaUserdataFuncCall(lua_State* state);
+  static int luaCallableCall(lua_State* state);
+
+  Callable errorHandler;
+  void handleError(int lua_error) const;
 
 private:
   lua_State *state;
-  Vector<Callable> callables;
-  Callable errorHandler;
-
+  
 private:
   void execute();
   void exposeConstructors();
@@ -52,8 +52,8 @@ private:
   void createRect2Metatable();
   void createPlaneMetatable();
   void createObjectMetatable();
-
-  void handleError(int lua_error);
+  void createCallableMetatable();
+  
 };
 
 #endif

--- a/luaCallable.cpp
+++ b/luaCallable.cpp
@@ -1,0 +1,70 @@
+#include "luaCallable.h"
+#include "lua.h"
+#include "core/templates/hashfuncs.h"
+
+
+LuaCallable::LuaCallable(Ref<Lua> p_lua, int ref, lua_State *p_state){
+    lua = p_lua;
+    funcRef = ref; 
+    state = p_state;
+    h = (uint32_t)hash_djb2_one_64((uint64_t)this);
+}
+
+LuaCallable::~LuaCallable(){
+}
+
+
+bool LuaCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
+	// Lambda callables are only compared by reference.
+	return p_a == p_b;
+}
+
+bool LuaCallable::compare_less(const CallableCustom *p_a, const CallableCustom *p_b) {
+	// Lambda callables are only compared by reference.
+	return p_a < p_b;
+}
+
+
+CallableCustom::CompareEqualFunc LuaCallable::get_compare_equal_func() const {
+	return compare_equal;
+}
+
+CallableCustom::CompareLessFunc LuaCallable::get_compare_less_func() const {
+	return compare_less;
+}
+
+ObjectID LuaCallable::get_object() const {
+    return lua->get_instance_id();
+}
+
+String LuaCallable::get_as_text() const {
+	// I dont know of a way to get a useful name from the function
+	return vformat("lua function %X", h);
+}
+
+uint32_t LuaCallable::hash() const {
+	return h;
+}
+
+void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	Vector<Variant> args;
+	args.resize(p_argcount);
+	for (int i = 0; i < p_argcount; i++) {
+		args.write[i] = *p_arguments[i];
+	}
+	
+	lua_rawgeti(state, LUA_REGISTRYINDEX, funcRef);
+	for (int i = 0; i < p_argcount; i++) {
+		lua->pushVariant(args[i]);
+	}
+	int ret = lua_pcall(state, p_argcount, 1 , 0);
+    if( ret != LUA_OK ){
+
+        if( !lua->errorHandler.is_valid() ){
+            print_error("Error during \"LuaCallable::call\"");
+        } 
+        lua->handleError( ret );
+    }
+	r_return_value = lua->getVariant(1);
+	lua_pop(state, 1);
+}

--- a/luaCallable.h
+++ b/luaCallable.h
@@ -1,0 +1,29 @@
+#ifndef LUACALLABLE_H
+#define LUACALLABLE_H
+
+#include "core/object/ref_counted.h"
+#include "core/variant/callable.h"
+#include "luasrc/lua.hpp"
+
+class Lua;
+
+class LuaCallable : public CallableCustom {
+    static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
+    static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
+    uint32_t h;
+public:
+    uint32_t hash() const override;
+    String get_as_text() const override;
+    CompareEqualFunc get_compare_equal_func() const override;
+    CompareLessFunc get_compare_less_func() const override;
+    ObjectID get_object() const override;
+    void call(const Variant **p_argument, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
+
+    LuaCallable(Ref<Lua> lua, int ref, lua_State *p_state);
+    ~LuaCallable();
+private:
+    int funcRef;
+    Ref<Lua> lua;
+    lua_State *state;
+};
+#endif


### PR DESCRIPTION
Callables are now passed as userdata with a metatable defining the __call method. This allows you to push a callable to lua as a function.

Additionally lua functions can now be pulled as a Callabled, to achieve this a new class was created `luaCallable`. It is a `customCallable`. It works by storing a luaL_ref of the lua function. When the Callable is called it will execute the function on the lua stack.

Since Callables can now be passed with push_variant this removes the need for expose_function thus it has been removed.