### PR TITLE
Error Handling, Coroutines and Object metamethod overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,18 @@ extends Node2D
 
 var lua: Lua
 
+func test(n: int):
+	if n != 5:
+		# This will raise a error in the lua state
+		return LuaError.new_err("N is not 5 but is %s" % n, LuaError.ERR_RUNTIME)
+	return n+5
+
 func _ready():
 	lua = Lua.new()
+	lua.push_variant(test, "test")
 	# Most methods return a LuaError
-	var err = lua.do_string("print(This wont work)")
+	# calling test with a type that is not a int would also raise a error.
+	var err = lua.do_string("test(6)")
 	# the static method is_err will check that the variant type is LuaError and that the errorType is not LuaError.ERR_NONE
 	if LuaError.is_err(err):
 		print("ERROR %d: " % err.type + err.msg)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ TODO
 
 Compiling
 ------------
-This build is for godot 4.0.0-alpha.
+This build is for godot 4.0.0-alphaX. X being the latest version. Will not be supporting older alpha builds.
 - Start by cloning the Godot 4.0.0-alpha [source](https://github.com/godotengine/godot) with this command `git clone https://github.com/godotengine/godot`
 
 - Next change directories into the modules folder and clone this repo with this command `git clone https://github.com/Trey2k/lua`
@@ -220,6 +220,31 @@ func _ready():
 	var player = lua.pull_variant("player")
 	print(player.pos)
 	print(player2.pos)
+```
+
+**Object metamethod overrides:**
+```gdscript
+extends Node2D
+var lua: Lua
+class Player:
+	var pos = Vector2(1, 0)
+	# Most metamethods can be overriden. The function names are the same as the metamethods.
+	func __index(index):
+		if index=="pos":
+			return pos
+		else:
+			return LuaError.new_err("Invalid index '%s'" % index)
+	func move_forward():
+		pos.x+=1
+
+func _ready():
+	lua = Lua.new()
+	lua.expose_constructor(Player, "Player")
+	var err = lua.do_string("player = Player() print(player.pos.x)  player.move_forward() -- this will cause our custom error ")
+	if LuaError.is_err(err):
+		print(err.msg)
+	var player = lua.pull_variant("player")
+	print(player.pos)
 ```
 **Using Coroutines:**
 ```gdscript

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ func _ready():
 	thread.load_string("
 	while true do
 		-- yield is exposed to lua when the thread is bound.
-		yield(10)
+		yield(1)
 		print('Hello world!')
 	end
 	")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Features
 - Call lua functions from GDScript.
 - Choose which libraries you want lua to have access to.
 - Custom LuaCallable type which allows you to get a lua function as a Callable. See [examples](#examples) below.
+- LuaError type which is used to report any errors this module or lua run into.
+- LuaThread type which creates a lua thread. This is not a OS thread but a coroutine. 
 - Object passed as userdata. See [examples](#examples) below.
+- Objects can override must of Luas metamethods. I.E. __index by defining a function with the same name.
 - Callables passed as userdata, which allows you to push a Callable as a lua function. see [examples](#examples) below.
 - Basic types are passed as userdata (currently: Vector2, Vector3, Color, Rect2, Plane) with a useful metatable. This means you can do things like:  
 ```lua
@@ -223,9 +226,6 @@ func _ready():
 extends Node2D
 var lua: Lua
 var thread: LuaThread
-
-func test(msg: String): 
-	print(msg)
 	
 func _ready():
 	lua = Lua.new()

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ def get_doc_classes():
     return [
         "Lua",
         "LuaThread",
+        "LuaError",
     ]
 
 def get_doc_path():

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ def configure(env):
 def get_doc_classes():
     return [
         "Lua",
+        "LuaThread",
     ]
 
 def get_doc_path():

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -16,9 +16,7 @@
 			<argument index="1" name="Args" type="Array">
 			</argument>
 			<description>
-				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua.
-				You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code].
-				This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null. 
+				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null. 
 			</description>
 		</method>
 		<method name="do_file">
@@ -35,6 +33,7 @@
 			</return>
 			<argument index="0" name="Code" type="String">
 			</argument>
+			<description>
 				loads a string with luaL_loadstring() and executes the top of the stack. Returns any errors
 			</description>
 		</method>
@@ -79,6 +78,17 @@
 			</description>
 		</method>
 	</methods>
+	<method name="bind_libs">
+			<return type="void">
+			</return>
+			<argument index="0" name="libNames" type="Array">
+			</argument>
+			<argument index="1" name="Args" type="Array">
+			</argument>
+			<description>
+				takes a array of lib names to bind to lua. Accepts the name of any built in lua lib. Not cap sensitive.
+			</description>
+		</method>
 	<constants>
 	</constants>
 </class>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Lua" inherits="RefCounted" version="4.0">
+<class name="Lua" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>
@@ -8,87 +8,63 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="call_function">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="LuaFunctionName" type="String">
-			</argument>
-			<argument index="1" name="Args" type="Array">
-			</argument>
+		<method name="bind_libs">
+			<return type="void" />
+			<argument index="0" name="Array" type="Array" />
 			<description>
-				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null. 
+			</description>
+		</method>
+		<method name="call_function">
+			<return type="Variant" />
+			<argument index="0" name="LuaFunctionName" type="String" />
+			<argument index="1" name="Args" type="Array" />
+			<description>
+				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null.
 			</description>
 		</method>
 		<method name="do_file">
-			<return type="LuaError">
-			</return>
-			<argument index="0" name="FilePath" type="String">
-			</argument>
+			<return type="LuaError" />
+			<argument index="0" name="File" type="String" />
 			<description>
 				Loads a file with luaL_laodfile() passing its absolute path.
 			</description>
 		</method>
 		<method name="do_string">
-			<return type="LuaError">
-			</return>
-			<argument index="0" name="Code" type="String">
-			</argument>
+			<return type="LuaError" />
+			<argument index="0" name="Code" type="String" />
 			<description>
 				loads a string with luaL_loadstring() and executes the top of the stack. Returns any errors
 			</description>
 		</method>
-		<method name="function_exists">
-			<return type="bool">
-			</return>
-			<argument index="0" name="LuaFunctionName" type="String">
-			</argument>
-			<description>
-				Returns [code]true[/code] only if [code]LuaFunctionName[/code] is defined in current Lua's state as a function.
-			</description>
-		</method>
-		<method name="push_variant">
-			<return type="LuaError">
-			</return>
-			<argument index="0" name="var" type="Variant">
-			</argument>
-			<argument index="1" name="Name" type="String">
-			</argument>
-			<description>
-				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
-			</description>
-		</method>
-		<method name="pull_variant">
-			<return type="Variant">
-			</return>
-			<argument index="0" name="Name" type="String">
-			</argument>
-			<description>
-				Will pull a copy of a global Variant from lua.
-			</description>
-		</method>
 		<method name="expose_constructor">
-			<return type="void">
-			</return>
-			<argument index="0" name="object" type="Object">
-			</argument>
-			<argument index="1" name="Name" type="String">
-			</argument>
+			<return type="LuaError" />
+			<argument index="0" name="Object" type="Object" />
+			<argument index="1" name="LuaConstructorName" type="String" />
 			<description>
 				Accepts any object that has a new() method. Allows lua to call the contructor aka the new() method. Exposed as a global with the given name.
 			</description>
 		</method>
-	</methods>
-	<method name="bind_libs">
-			<return type="void">
-			</return>
-			<argument index="0" name="libNames" type="Array">
-			</argument>
-			<argument index="1" name="Args" type="Array">
-			</argument>
+		<method name="function_exists">
+			<return type="bool" />
+			<argument index="0" name="LuaFunctionName" type="String" />
 			<description>
-				takes a array of lib names to bind to lua. Accepts the name of any built in lua lib. Not cap sensitive.
+				Returns [code]true[/code] only if [code]LuaFunctionName[/code] is defined in current Lua's state as a function.
 			</description>
 		</method>
-	<constants>
-	</constants>
+		<method name="pull_variant">
+			<return type="Variant" />
+			<argument index="0" name="Name" type="String" />
+			<description>
+				Will pull a copy of a global Variant from lua.
+			</description>
+		</method>
+		<method name="push_variant">
+			<return type="LuaError" />
+			<argument index="0" name="var" type="Variant" />
+			<argument index="1" name="Name" type="String" />
+			<description>
+				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -22,7 +22,7 @@
 			</description>
 		</method>
 		<method name="do_file">
-			<return type="void">
+			<return type="LuaError">
 			</return>
 			<argument index="0" name="FilePath" type="String">
 			</argument>
@@ -31,11 +31,11 @@
 			</description>
 		</method>
 		<method name="do_string">
-			<return type="void">
+			<return type="LuaError">
 			</return>
 			<argument index="0" name="Code" type="String">
 			</argument>
-				loas a string with luaL_loadstring() and executes the top of the stack
+				loads a string with luaL_loadstring() and executes the top of the stack. Returns any errors
 			</description>
 		</method>
 		<method name="function_exists">
@@ -48,14 +48,14 @@
 			</description>
 		</method>
 		<method name="push_variant">
-			<return type="bool">
+			<return type="LuaError">
 			</return>
 			<argument index="0" name="var" type="Variant">
 			</argument>
 			<argument index="1" name="Name" type="String">
 			</argument>
 			<description>
-				Will push a copy of a Variant to lua as a global.
+				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
 			</description>
 		</method>
 		<method name="pull_variant">
@@ -76,15 +76,6 @@
 			</argument>
 			<description>
 				Accepts any object that has a new() method. Allows lua to call the contructor aka the new() method. Exposed as a global with the given name.
-			</description>
-		</method>
-		<method name="set_error_handler">
-			<return type="void">
-			</return>
-			<argument index="0" name="Callback" type="Callable">
-			</argument>
-			<description>
-				Takes any Callable that has no return value and takes 1 argument of the type String. The Callable will be called any time the lua state runs into a error with the string being the error message.
 			</description>
 		</method>
 	</methods>

--- a/docs/Lua.xml
+++ b/docs/Lua.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="Lua" inherits="RefCounted" version="3.2">
+<class name="Lua" inherits="RefCounted" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/docs/LuaError.xml
+++ b/docs/LuaError.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaError" inherits="RefCounted" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+		LuaError contains a error message and type. If a LuaError is ever pushed to the stack it will raise a error in the lua state. Meaning if a exposed GD function returns a lua error. That will raise a error.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="new_err">
+			<return type="void">
+			</return>
+			<argument index="0" name="msg" type="String">
+			</argument>
+            <argument index="1" name="type" type="ErrorType">
+			</argument>
+			<description>
+				This is a static method that exists so you dont have to call LuaError.new() and err.set_info(msg, type) every time. It creates a new error and calls set_info passing msd and type.
+			</description>
+		</method>
+        <method name="err_none">
+			<return type="void">
+			</return>
+			<description>
+				This is a static method that creates a new error with no message and type of ERR_NONE.
+			</description>
+		</method>
+        <method name="is_err">
+			<return type="void">
+			</return>
+			<argument index="0" name="var" type="Variant">
+			</argument>
+			<description>
+				This is a static method that checks if the type of var is LuaError and if the error type is not ERR_NONE.
+			</description>
+		</method>
+        <method name="set_info">
+			<return type="void">
+			</return>
+			<argument index="0" name="msg" type="String">
+			</argument>
+            <argument index="1" name="type" type="ErrorType">
+			</argument>
+			<description>
+				Sets the errors message and type.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/docs/LuaError.xml
+++ b/docs/LuaError.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LuaError" inherits="RefCounted" version="4.0">
+<class name="LuaError" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>
@@ -8,45 +8,57 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="new_err">
-			<return type="LuaError">
-			</return>
-			<argument index="0" name="msg" type="String">
-			</argument>
-            <argument index="1" name="type" type="ErrorType">
-			</argument>
+		<method name="new_err" qualifiers="static">
+			<return type="LuaError" />
+			<argument index="0" name="Message" type="String" />
+			<argument index="1" name="Type" type="int" enum="LuaError.ErrorType" default="2" />
 			<description>
 				This is a static method that exists so you dont have to call LuaError.new() and err.set_info(msg, type) every time. It creates a new error and calls set_info passing msd and type.
 			</description>
 		</method>
-        <method name="err_none">
-			<return type="LuaError">
-			</return>
+		<method name="err_none" qualifiers="static">
+			<return type="LuaError" />
 			<description>
 				This is a static method that creates a new error with no message and type of ERR_NONE.
 			</description>
 		</method>
-        <method name="is_err">
-			<return type="bool">
-			</return>
-			<argument index="0" name="var" type="Variant">
-			</argument>
+		<method name="is_err" qualifiers="static">
+			<return type="bool" />
+			<argument index="0" name="var" type="Variant" />
 			<description>
 				This is a static method that checks if the type of var is LuaError and if the error type is not ERR_NONE.
 			</description>
 		</method>
-        <method name="set_info">
-			<return type="void">
-			</return>
-			<argument index="0" name="msg" type="String">
-			</argument>
-            <argument index="1" name="type" type="ErrorType">
-			</argument>
-			<description>
-				Sets the errors message and type.
-			</description>
-		</method>
 	</methods>
+	<members>
+		<member name="msg" type="String" setter="set_msg" getter="get_msg" default="&quot;&quot;">
+			The error message. Will also contain the stack trace if apllicable.
+		</member>
+		<member name="type" type="int" setter="set_type" getter="get_type" enum="LuaError.ErrorType" default="0">
+			The error type.
+		</member>
+	</members>
 	<constants>
+		<constant name="ERR_NONE" value="0" enum="ErrorType">
+			Indicates no error.
+		</constant>
+		<constant name="ERR_TYPE" value="1" enum="ErrorType">
+			Indicates a error with argument types.
+		</constant>
+		<constant name="ERR_RUNTIME" value="2" enum="ErrorType">
+			Indicates a generic runtime error.
+		</constant>
+		<constant name="ERR_SYNTAX" value="3" enum="ErrorType">
+			Indicates a syntax error.
+		</constant>
+		<constant name="ERR_MEMORY" value="4" enum="ErrorType">
+			Indicates a memory error.
+		</constant>
+		<constant name="ERR_ERR" value="5" enum="ErrorType">
+			Indicates a error running the internal lua error handler. Please report.
+		</constant>
+		<constant name="ERR_FILE" value="6" enum="ErrorType">
+			Indicates a error while opening a file.
+		</constant>
 	</constants>
 </class>

--- a/docs/LuaError.xml
+++ b/docs/LuaError.xml
@@ -9,7 +9,7 @@
 	</tutorials>
 	<methods>
 		<method name="new_err">
-			<return type="void">
+			<return type="LuaError">
 			</return>
 			<argument index="0" name="msg" type="String">
 			</argument>
@@ -20,14 +20,14 @@
 			</description>
 		</method>
         <method name="err_none">
-			<return type="void">
+			<return type="LuaError">
 			</return>
 			<description>
 				This is a static method that creates a new error with no message and type of ERR_NONE.
 			</description>
 		</method>
         <method name="is_err">
-			<return type="void">
+			<return type="bool">
 			</return>
 			<argument index="0" name="var" type="Variant">
 			</argument>

--- a/docs/LuaThread.xml
+++ b/docs/LuaThread.xml
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LuaError" inherits="RefCounted" version="4.0">
+<class name="LuaThread" inherits="RefCounted" version="4.0">
 	<brief_description>
 	</brief_description>
 	<description>
-		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. 
-        Instead of executing a file or string directly you load it into the state. 
-        Every time the resume method is caleld the lua code will execute untill yield is called from lua.
+		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. Instead of executing a file or string directly you load it into the state. Every time the resume method is caleld the lua code will execute untill yield is called from lua.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="new_thread">
+			<return type="void">
+			</return>
+			<argument index="0" name="lua" type="Lua">
+			</argument>
+			<description>
+				This is a static method that exists so you dont have to call LuaThread.new() and thread.bind(lua) every time. It creates a new thread and calls bind passing lua.
+			</description>
+		</method>
 		<method name="bind">
 			<return type="void">
 			</return>

--- a/docs/LuaThread.xml
+++ b/docs/LuaThread.xml
@@ -9,7 +9,7 @@
 	</tutorials>
 	<methods>
 		<method name="new_thread">
-			<return type="void">
+			<return type="LuaThread">
 			</return>
 			<argument index="0" name="lua" type="Lua">
 			</argument>
@@ -36,7 +36,7 @@
 			</description>
 		</method>
         <method name="load_file">
-			<return type="void">
+			<return type="LuaError">
 			</return>
 			<argument index="0" name="filePath" type="String">
 			</argument>
@@ -52,7 +52,7 @@
 			</description>
 		</method>
         <method name="is_done">
-			<return type="Variant">
+			<return type="bool">
 			</return>
 			<description>
 				Returns true if the thread is finished executing.

--- a/docs/LuaThread.xml
+++ b/docs/LuaThread.xml
@@ -1,64 +1,53 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LuaThread" inherits="RefCounted" version="4.0">
+<class name="LuaThread" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
+		A coroutine.
 	<description>
 		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. Instead of executing a file or string directly you load it into the state. Every time the resume method is caleld the lua code will execute untill yield is called from lua.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="new_thread">
-			<return type="LuaThread">
-			</return>
-			<argument index="0" name="lua" type="Lua">
-			</argument>
+		<method name="new_thread" qualifiers="static">
+			<return type="LuaThread" />
+			<argument index="0" name="lua" type="Lua" />
 			<description>
 				This is a static method that exists so you dont have to call LuaThread.new() and thread.bind(lua) every time. It creates a new thread and calls bind passing lua.
 			</description>
 		</method>
 		<method name="bind">
-			<return type="void">
-			</return>
-			<argument index="0" name="lua" type="Lua">
-			</argument>
+			<return type="void" />
+			<argument index="0" name="lua" type="Lua" />
 			<description>
 				Binds the thread to a lua object. All threads attached to the same object share resources.
 			</description>
 		</method>
-        <method name="load_string">
-			<return type="void">
-			</return>
-			<argument index="0" name="code" type="String">
-			</argument>
-			<description>
-				Loads a string into the threads state.
-			</description>
-		</method>
-        <method name="load_file">
-			<return type="LuaError">
-			</return>
-			<argument index="0" name="filePath" type="String">
-			</argument>
+		<method name="load_file">
+			<return type="LuaError" />
+			<argument index="0" name="arg0" type="String" />
 			<description>
 				Loads a file into the threads state.
 			</description>
 		</method>
-        <method name="reumse">
-			<return type="Variant">
-			</return>
+		<method name="load_string">
+			<return type="void" />
+			<argument index="0" name="arg0" type="String" />
+			<description>
+				Loads a string into the threads state.
+			</description>
+		</method>
+		<method name="resume">
+			<return type="Variant" />
 			<description>
 				Resumes or starts the thread. Will either return a Array of arguments passed by lua in yield() or a LuaError.
 			</description>
 		</method>
-        <method name="is_done">
-			<return type="bool">
-			</return>
+		<method name="is_done">
+			<return type="bool" />
 			<description>
 				Returns true if the thread is finished executing.
 			</description>
 		</method>
 	</methods>
-	<constants>
-	</constants>
 </class>

--- a/docs/LuaThread.xml
+++ b/docs/LuaThread.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaError" inherits="RefCounted" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. 
+        Instead of executing a file or string directly you load it into the state. 
+        Every time the resume method is caleld the lua code will execute untill yield is called from lua.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="bind">
+			<return type="void">
+			</return>
+			<argument index="0" name="lua" type="Lua">
+			</argument>
+			<description>
+				Binds the thread to a lua object. All threads attached to the same object share resources.
+			</description>
+		</method>
+        <method name="load_string">
+			<return type="void">
+			</return>
+			<argument index="0" name="code" type="String">
+			</argument>
+			<description>
+				Loads a string into the threads state.
+			</description>
+		</method>
+        <method name="load_file">
+			<return type="void">
+			</return>
+			<argument index="0" name="filePath" type="String">
+			</argument>
+			<description>
+				Loads a file into the threads state.
+			</description>
+		</method>
+        <method name="reumse">
+			<return type="Variant">
+			</return>
+			<description>
+				Resumes or starts the thread. Will either return a Array of arguments passed by lua in yield() or a LuaError.
+			</description>
+		</method>
+        <method name="is_done">
+			<return type="Variant">
+			</return>
+			<description>
+				Returns true if the thread is finished executing.
+			</description>
+		</method>
+	</methods>
+	<constants>
+	</constants>
+</class>

--- a/lua.cpp
+++ b/lua.cpp
@@ -245,6 +245,10 @@ LuaError* Lua::pushVariant(Variant var, lua_State* state) {
         case Variant::Type::OBJECT: {
             // If the type being pushed is a lua error, Raise a error
             if (LuaError* err = Object::cast_to<LuaError>(var.operator Object*()); err != nullptr) {
+                if (err->getType() == LuaError::ERR_NONE) {
+                    break;
+                }
+                
                 lua_pushstring(state, err->getMsg().ascii().get_data());
                 lua_error(state);
                 break;
@@ -995,7 +999,7 @@ void Lua::createObjectMetatable() {
         
         return 0;
     });
-    
+
     LUA_METAMETHOD_TEMPLATE(state, -1, "__newindex", {
         // If object overrides
         if (arg1.has_method("__newindex")) {
@@ -1024,6 +1028,231 @@ void Lua::createObjectMetatable() {
             if (ptr != nullptr) memdelete(ptr);
         }
         return 0;
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__call", {
+        if (!arg1.has_method("__call")) {
+                return 0;
+        }
+        int argc = lua_gettop(inner_state);
+        
+        Array args;
+        for (int i = 1; i < argc; i++) {
+                args.push_back(Lua::getVariant(i+1, inner_state, OBJ));
+        }
+
+        Lua::pushVariant(arg1.call("__call", args), inner_state);
+        return 1;
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__tostring", {
+        // If object overrides
+        if (!arg1.has_method("__tostring")) {
+            return 0;
+        }
+
+        Lua::pushVariant(arg1.call("__tostring"), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__metatable", {
+        // If object overrides
+        if (!arg1.has_method("__metatable")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__metatable", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__len", {
+        // If object overrides
+        if (!arg1.has_method("__len")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__len"), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__unm", {
+        // If object overrides
+        if (!arg1.has_method("__unm")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__unm"), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__add", {
+        // If object overrides
+        if (!arg1.has_method("__add")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__add", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__sub", {
+        // If object overrides
+        if (!arg1.has_method("__sub")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__sub", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__mul", {
+        // If object overrides
+        if (!arg1.has_method("__mul")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__mul", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__div", {
+        // If object overrides
+        if (!arg1.has_method("__div")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__div", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__idiv", {
+        // If object overrides
+        if (!arg1.has_method("__idiv")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__idiv", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__mod", {
+        // If object overrides
+        if (!arg1.has_method("__mod")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__mod", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__pow", {
+        // If object overrides
+        if (!arg1.has_method("__pow")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__pow", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__concat", {
+        // If object overrides
+        if (!arg1.has_method("__concat")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__concat", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__band", {
+        // If object overrides
+        if (!arg1.has_method("__band")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__band", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__bor", {
+        // If object overrides
+        if (!arg1.has_method("__bor")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__bor", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__bxor", {
+        // If object overrides
+        if (!arg1.has_method("__bxor")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__bxor", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__bnot", {
+        // If object overrides
+        if (!arg1.has_method("__bnot")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__bnot", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__shl", {
+        // If object overrides
+        if (!arg1.has_method("__shl")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__shl", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__shr", {
+        // If object overrides
+        if (!arg1.has_method("__shr")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__shr", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__eq", {
+        // If object overrides
+        if (!arg1.has_method("__eq")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__eq", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__lt", {
+        // If object overrides
+        if (!arg1.has_method("__lt")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__lt", arg2), inner_state);
+        return 1;        
+    });
+
+    LUA_METAMETHOD_TEMPLATE(state, -1, "__le", {
+        // If object overrides
+        if (!arg1.has_method("__le")) {
+            return 0;
+        }
+        
+        Lua::pushVariant(arg1.call("__le", arg2), inner_state);
+        return 1;        
     });
 
     lua_pop(state, 1);

--- a/lua.cpp
+++ b/lua.cpp
@@ -123,7 +123,7 @@ LuaError* Lua::doFile(String fileName) {
     Error error;
     Ref<FileAccess> file = FileAccess::open(fileName, FileAccess::READ, &error);
     if (error != Error::OK) {
-        return LuaError::newError(vformat("error '%s' while opening file '%s'", error_names[error], fileName), LuaError::ERR_FILE);
+        return LuaError::newErr(vformat("error '%s' while opening file '%s'", error_names[error], fileName), LuaError::ERR_FILE);
     }
 
     String path = file->get_path_absolute();
@@ -271,7 +271,7 @@ LuaError* Lua::pushVariant(Variant var) const {
         }
         default:
             lua_pushnil(state);
-            return LuaError::newError(vformat("can't pass Variants of type \"%s\" to Lua.", Variant::get_type_name(var.get_type())), LuaError::ERR_TYPE);
+            return LuaError::newErr(vformat("can't pass Variants of type \"%s\" to Lua.", Variant::get_type_name(var.get_type())), LuaError::ERR_TYPE);
     }
     return LuaError::errNone();
 }
@@ -336,7 +336,7 @@ Variant Lua::getVariant(int index) const {
             break;
         }
         default:
-            result = LuaError::newError(vformat("unkown lua type '%d' in Lua::getVariant", type), LuaError::ERR_RUNTIME);
+            result = LuaError::newErr(vformat("unkown lua type '%d' in Lua::getVariant", type), LuaError::ERR_RUNTIME);
     }
     return result;
 }
@@ -377,7 +377,7 @@ LuaError* Lua::handleError(int lua_error) const {
         default: break;
     }
     
-    return LuaError::newError(msg, static_cast<LuaError::ErrorType>(lua_error));
+    return LuaError::newErr(msg, static_cast<LuaError::ErrorType>(lua_error));
 }
 
 // Lua functions
@@ -441,7 +441,7 @@ static std::map<void*, Variant*> luaObjects;
 LuaError* Lua::exposeObjectConstructor(Object* obj, String name) {
     // Make sure we are able to call new
     if (!obj->has_method("new")) {
-        return LuaError::newError("during \"Lua::exposeObjectConstructor\" method 'new' does not exist.", LuaError::ERR_RUNTIME);
+        return LuaError::newErr("during \"Lua::exposeObjectConstructor\" method 'new' does not exist.", LuaError::ERR_RUNTIME);
     }
     lua_pushlightuserdata(state, obj);
     lua_pushcclosure(state, LUA_LAMBDA_TEMPLATE({

--- a/lua.cpp
+++ b/lua.cpp
@@ -241,7 +241,6 @@ LuaError* Lua::pushVariant(Variant var) const {
         case Variant::Type::OBJECT: {
             // If the type being pushed is a lua error, Raise a error
             if (LuaError* err = Object::cast_to<LuaError>(var.operator Object*()); err != nullptr) {
-                print_line("testing");
                 lua_pushstring(state, err->getMsg().ascii().get_data());
                 lua_error(state);
                 break;

--- a/lua.cpp
+++ b/lua.cpp
@@ -837,6 +837,12 @@ void Lua::createObjectMetatable() {
     luaL_newmetatable(state, "mt_Object");
 
     LUA_METAMETHOD_TEMPLATE(state, -1, "__index", {
+        // If object overrides
+        if (arg1.has_method("__index")) {
+            lua->pushVariant(arg1.call("__index", arg2));
+            return 1;
+        }
+
         Array allowedFuncs = Array();
         if (arg1.has_method("lua_funcs")) {
             allowedFuncs = arg1.call("lua_funcs");
@@ -864,6 +870,12 @@ void Lua::createObjectMetatable() {
     });
     
     LUA_METAMETHOD_TEMPLATE(state, -1, "__newindex", {
+        // If object overrides
+        if (arg1.has_method("__newindex")) {
+            lua->pushVariant(arg1.call("__newindex", arg2, arg3));
+            return 1;
+        }
+
         Array allowedFields = Array();
         if (arg1.has_method("lua_fields")) {
             allowedFields = arg1.call("lua_fields");

--- a/lua.h
+++ b/lua.h
@@ -31,6 +31,9 @@ public:
   LuaError* pushVariant(Variant var) const;
   LuaError* pushGlobalVariant(Variant var, String name);
   LuaError* exposeObjectConstructor(Object* obj, String name);
+  LuaError* handleError(int lua_error) const;
+
+  static LuaError* handleError(const StringName &func, Callable::CallError error, const Variant** p_arguments, int argc);
 
   // Lua functions
   static int luaErrorHandler(lua_State* state);
@@ -38,8 +41,6 @@ public:
   static int luaExposedFuncCall(lua_State* state);
   static int luaUserdataFuncCall(lua_State* state);
   static int luaCallableCall(lua_State* state);
-
-  LuaError* handleError(int lua_error) const;
 
 private:
   lua_State *state;

--- a/lua.h
+++ b/lua.h
@@ -4,6 +4,7 @@
 #include "core/object/ref_counted.h"
 #include "core/core_bind.h"
 #include "luasrc/lua.hpp"
+#include "luaError.h"
 
 #include <string>
 
@@ -16,35 +17,36 @@ protected:
 public:
   Lua();
   ~Lua();
-  void doFile(String fileName);
-  void doString(String code);
   void bindLibs(Array libs);
-  void exposeFunction(Callable func, String name); 
-  void setErrorHandler(Callable errorHandler);
+  void exposeFunction(Callable func, String name);
   void exposeObjectConstructor(Object* obj, String name);
 
-  bool pushVariant(Variant var) const;
-  bool pushGlobalVariant(Variant var, String name);
   bool luaFunctionExists(String function_name);
   
   Variant getVariant(int index = -1) const;
   Variant pullVariant(String name);
   Variant callFunction(String function_name, Array args);
 
+  LuaError* doFile(String fileName);
+  LuaError* doString(String code);
+  LuaError* pushVariant(Variant var) const;
+  LuaError* pushGlobalVariant(Variant var, String name);
+
   // Lua functions
+  static int luaErrorHandler(lua_State* state);
   static int luaPrint(lua_State* state);
   static int luaExposedFuncCall(lua_State* state);
   static int luaUserdataFuncCall(lua_State* state);
   static int luaCallableCall(lua_State* state);
 
-  Callable errorHandler;
-  void handleError(int lua_error) const;
+  LuaError* handleError(int lua_error) const;
 
 private:
   lua_State *state;
   
 private:
-  void execute();
+  LuaError* execute(int handlerIndex);
+
   void exposeConstructors();
   void createVector2Metatable();
   void createVector3Metatable();

--- a/lua.h
+++ b/lua.h
@@ -23,16 +23,23 @@ public:
   bool luaFunctionExists(String function_name);
   
   Variant getVariant(int index = -1) const;
+  Variant getVariant(int index, lua_State* L) const;
   Variant pullVariant(String name);
   Variant callFunction(String function_name, Array args);
 
   LuaError* doFile(String fileName);
   LuaError* doString(String code);
   LuaError* pushVariant(Variant var) const;
+  static LuaError* pushVariant(Variant var, lua_State* state);
   LuaError* pushGlobalVariant(Variant var, String name);
   LuaError* exposeObjectConstructor(Object* obj, String name);
-  LuaError* handleError(int lua_error) const;
+  
 
+  lua_State* newThread();
+  lua_State* getState();
+
+  LuaError* handleError(int lua_error) const;
+  static LuaError* handleError(int lua_error, lua_State* state);
   static LuaError* handleError(const StringName &func, Callable::CallError error, const Variant** p_arguments, int argc);
 
   // Lua functions

--- a/lua.h
+++ b/lua.h
@@ -23,7 +23,7 @@ public:
   bool luaFunctionExists(String function_name);
   
   Variant getVariant(int index = -1) const;
-  Variant getVariant(int index, lua_State* L) const;
+  static Variant getVariant(int index, lua_State* L, Ref<RefCounted> obj);
   Variant pullVariant(String name);
   Variant callFunction(String function_name, Array args);
 

--- a/lua.h
+++ b/lua.h
@@ -9,60 +9,58 @@
 #include <string>
 
 class Lua : public RefCounted {
-  GDCLASS(Lua, RefCounted);
+    GDCLASS(Lua, RefCounted);
 
-protected:
-  static void _bind_methods();
+    protected:
+        static void _bind_methods();
 
-public:
-  Lua();
-  ~Lua();
-  void bindLibs(Array libs);
-  void exposeFunction(Callable func, String name);
-  
-  bool luaFunctionExists(String function_name);
-  
-  Variant getVariant(int index = -1) const;
-  static Variant getVariant(int index, lua_State* L, Ref<RefCounted> obj);
-  Variant pullVariant(String name);
-  Variant callFunction(String function_name, Array args);
+    public:
+        Lua();
+        ~Lua();
+        void bindLibs(Array libs);
+        void exposeFunction(Callable func, String name);
+        
+        bool luaFunctionExists(String function_name);
+        
+        Variant getVariant(int index = -1) const;
+        static Variant getVariant(int index, lua_State* L, Ref<RefCounted> obj);
+        Variant pullVariant(String name);
+        Variant callFunction(String function_name, Array args);
 
-  LuaError* doFile(String fileName);
-  LuaError* doString(String code);
-  LuaError* pushVariant(Variant var) const;
-  static LuaError* pushVariant(Variant var, lua_State* state);
-  LuaError* pushGlobalVariant(Variant var, String name);
-  LuaError* exposeObjectConstructor(Object* obj, String name);
-  
+        LuaError* doFile(String fileName);
+        LuaError* doString(String code);
+        LuaError* pushVariant(Variant var) const;
+        static LuaError* pushVariant(Variant var, lua_State* state);
+        LuaError* pushGlobalVariant(Variant var, String name);
+        LuaError* exposeObjectConstructor(Object* obj, String name);
+        
 
-  lua_State* newThread();
-  lua_State* getState();
+        lua_State* newThread();
+        lua_State* getState();
 
-  LuaError* handleError(int lua_error) const;
-  static LuaError* handleError(int lua_error, lua_State* state);
-  static LuaError* handleError(const StringName &func, Callable::CallError error, const Variant** p_arguments, int argc);
+        LuaError* handleError(int lua_error) const;
+        static LuaError* handleError(int lua_error, lua_State* state);
+        static LuaError* handleError(const StringName &func, Callable::CallError error, const Variant** p_arguments, int argc);
 
-  // Lua functions
-  static int luaErrorHandler(lua_State* state);
-  static int luaPrint(lua_State* state);
-  static int luaExposedFuncCall(lua_State* state);
-  static int luaUserdataFuncCall(lua_State* state);
-  static int luaCallableCall(lua_State* state);
+        // Lua functions
+        static int luaErrorHandler(lua_State* state);
+        static int luaPrint(lua_State* state);
+        static int luaExposedFuncCall(lua_State* state);
+        static int luaUserdataFuncCall(lua_State* state);
+        static int luaCallableCall(lua_State* state);
 
-private:
-  lua_State *state;
-  
-private:
-  LuaError* execute(int handlerIndex);
+    private:
+        lua_State *state;
+        LuaError* execute(int handlerIndex);
 
-  void exposeConstructors();
-  void createVector2Metatable();
-  void createVector3Metatable();
-  void createColorMetatable();
-  void createRect2Metatable();
-  void createPlaneMetatable();
-  void createObjectMetatable();
-  void createCallableMetatable();
+        void exposeConstructors();
+        void createVector2Metatable();
+        void createVector3Metatable();
+        void createColorMetatable();
+        void createRect2Metatable();
+        void createPlaneMetatable();
+        void createObjectMetatable();
+        void createCallableMetatable();
 };
 
 #endif

--- a/lua.h
+++ b/lua.h
@@ -19,8 +19,7 @@ public:
   ~Lua();
   void bindLibs(Array libs);
   void exposeFunction(Callable func, String name);
-  void exposeObjectConstructor(Object* obj, String name);
-
+  
   bool luaFunctionExists(String function_name);
   
   Variant getVariant(int index = -1) const;
@@ -31,6 +30,7 @@ public:
   LuaError* doString(String code);
   LuaError* pushVariant(Variant var) const;
   LuaError* pushGlobalVariant(Variant var, String name);
+  LuaError* exposeObjectConstructor(Object* obj, String name);
 
   // Lua functions
   static int luaErrorHandler(lua_State* state);

--- a/luaCallable.cpp
+++ b/luaCallable.cpp
@@ -56,6 +56,7 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
     if (ret != LUA_OK) {
         r_return_value = lua->handleError(ret);
     } else r_return_value = lua->getVariant(1);
+	
 	lua_pop(state, 1);
 }
 

--- a/luaCallable.cpp
+++ b/luaCallable.cpp
@@ -3,8 +3,8 @@
 #include "core/templates/hashfuncs.h"
 
 // I used "GDScriptLambdaCallable" as a template for this
-LuaCallable::LuaCallable(Ref<Lua> p_lua, int ref, lua_State *p_state){
-    lua = p_lua;
+LuaCallable::LuaCallable(Ref<RefCounted> p_obj, int ref, lua_State *p_state){
+    obj = p_obj;
     funcRef = ref; 
     state = p_state;
     h = (uint32_t)hash_djb2_one_64((uint64_t)this);
@@ -29,7 +29,7 @@ CallableCustom::CompareLessFunc LuaCallable::get_compare_less_func() const {
 }
 
 ObjectID LuaCallable::get_object() const {
-    return lua->get_instance_id();
+    return obj->get_instance_id();
 }
 
 String LuaCallable::get_as_text() const {
@@ -48,14 +48,14 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
 
 	// Push all the argument on to the stack
 	for (int i = 0; i < p_argcount; i++) {
-		lua->pushVariant(*p_arguments[i], state);
+		Lua::pushVariant(*p_arguments[i], state);
 	}
 
 	// execute the function using a protected call.
 	int ret = lua_pcall(state, p_argcount, 1, 0);
     if (ret != LUA_OK) {
         r_return_value = Lua::handleError(ret, state);
-    } else r_return_value = lua->getVariant(1, state);
+    } else r_return_value = Lua::getVariant(1, state, obj);
 
 	lua_pop(state, 1);
 }

--- a/luaCallable.cpp
+++ b/luaCallable.cpp
@@ -48,15 +48,15 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
 
 	// Push all the argument on to the stack
 	for (int i = 0; i < p_argcount; i++) {
-		lua->pushVariant(*p_arguments[i]);
+		lua->pushVariant(*p_arguments[i], state);
 	}
 
 	// execute the function using a protected call.
 	int ret = lua_pcall(state, p_argcount, 1, 0);
     if (ret != LUA_OK) {
-        r_return_value = lua->handleError(ret);
-    } else r_return_value = lua->getVariant(1);
-	
+        r_return_value = Lua::handleError(ret, state);
+    } else r_return_value = lua->getVariant(1, state);
+
 	lua_pop(state, 1);
 }
 

--- a/luaCallable.cpp
+++ b/luaCallable.cpp
@@ -54,12 +54,8 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
 	// execute the function using a protected call.
 	int ret = lua_pcall(state, p_argcount, 1, 0);
     if (ret != LUA_OK) {
-        if (!lua->errorHandler.is_valid()) {
-            print_error("Error during \"LuaCallable::call\"");
-        } 
-        lua->handleError(ret);
-    }
-	r_return_value = lua->getVariant(1);
+        r_return_value = lua->handleError(ret);
+    } else r_return_value = lua->getVariant(1);
 	lua_pop(state, 1);
 }
 

--- a/luaCallable.h
+++ b/luaCallable.h
@@ -5,8 +5,6 @@
 #include "core/variant/callable.h"
 #include "luasrc/lua.hpp"
 
-class Lua;
-
 class LuaCallable : public CallableCustom {
     static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
     static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
@@ -21,11 +19,11 @@ public:
 
     int getFuncRef();
 
-    LuaCallable(Ref<Lua> lua, int ref, lua_State *p_state);
+    LuaCallable(Ref<RefCounted> obj, int ref, lua_State *p_state);
     virtual ~LuaCallable() = default;
 private:
     int funcRef;
-    Ref<Lua> lua;
+    Ref<RefCounted> obj;
     lua_State *state;
 };
 

--- a/luaCallable.h
+++ b/luaCallable.h
@@ -9,22 +9,22 @@ class LuaCallable : public CallableCustom {
     static bool compare_equal(const CallableCustom *p_a, const CallableCustom *p_b);
     static bool compare_less(const CallableCustom *p_a, const CallableCustom *p_b);
     uint32_t h;
-public:
-    uint32_t hash() const override;
-    String get_as_text() const override;
-    CompareEqualFunc get_compare_equal_func() const override;
-    CompareLessFunc get_compare_less_func() const override;
-    ObjectID get_object() const override;
-    void call(const Variant **p_argument, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
+    public:
+        uint32_t hash() const override;
+        String get_as_text() const override;
+        CompareEqualFunc get_compare_equal_func() const override;
+        CompareLessFunc get_compare_less_func() const override;
+        ObjectID get_object() const override;
+        void call(const Variant **p_argument, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
-    int getFuncRef();
+        int getFuncRef();
 
-    LuaCallable(Ref<RefCounted> obj, int ref, lua_State *p_state);
-    virtual ~LuaCallable() = default;
-private:
-    int funcRef;
-    Ref<RefCounted> obj;
-    lua_State *state;
+        LuaCallable(Ref<RefCounted> obj, int ref, lua_State *p_state);
+        virtual ~LuaCallable() = default;
+    private:
+        int funcRef;
+        Ref<RefCounted> obj;
+        lua_State *state;
 };
 
 #endif

--- a/luaError.cpp
+++ b/luaError.cpp
@@ -12,6 +12,19 @@ LuaError* LuaError::errNone() {
     return err;
 }
 
+// Test if the variants type is a Lua error
+bool LuaError::isErr(Variant var) {
+    if (var.get_type() != Variant::Type::OBJECT) {
+        return false;
+    }
+
+    if (LuaError* err = Object::cast_to<LuaError>(var.operator Object*()); err != nullptr) {
+        return err->getType() != ERR_NONE;
+    }
+
+    return false;
+}
+
 void LuaError::setInfo(String msg, ErrorType type) {
     errType = type;
     errMsg = msg;
@@ -42,11 +55,15 @@ LuaError::ErrorType LuaError::getType() {
 }
 
 void LuaError::_bind_methods(){
-    ClassDB::bind_static_method("LuaError", D_METHOD("new_error", "Message", "Type"), &LuaError::newError);
+    ClassDB::bind_static_method("LuaError", D_METHOD("new_err", "Message", "Type"), &LuaError::newError);
+    ClassDB::bind_static_method("LuaError", D_METHOD("error_none"), &LuaError::errNone);
+    ClassDB::bind_static_method("LuaError", D_METHOD("is_error", "var"), &LuaError::isErr);
+
     ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
     ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);
     ClassDB::bind_method(D_METHOD("set_type","Type"), &LuaError::setType);
     ClassDB::bind_method(D_METHOD("get_type"), &LuaError::getType);
+    
 
     ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type");
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "msg"), "set_msg", "get_msg");

--- a/luaError.cpp
+++ b/luaError.cpp
@@ -1,6 +1,6 @@
 #include "luaError.h"
 
-LuaError* LuaError::newError(String msg, ErrorType type) {
+LuaError* LuaError::newErr(String msg, ErrorType type) {
     LuaError* err = memnew(LuaError);
     err->setInfo(msg, static_cast<LuaError::ErrorType>(type));
     return err;
@@ -55,9 +55,9 @@ LuaError::ErrorType LuaError::getType() {
 }
 
 void LuaError::_bind_methods(){
-    ClassDB::bind_static_method("LuaError", D_METHOD("new_error", "Message", "Type"), &LuaError::newError);
-    ClassDB::bind_static_method("LuaError", D_METHOD("error_none"), &LuaError::errNone);
-    ClassDB::bind_static_method("LuaError", D_METHOD("is_error", "var"), &LuaError::isErr);
+    ClassDB::bind_static_method("LuaError", D_METHOD("new_err", "Message", "Type"), &LuaError::newErr);
+    ClassDB::bind_static_method("LuaError", D_METHOD("err_none"), &LuaError::errNone);
+    ClassDB::bind_static_method("LuaError", D_METHOD("is_err", "var"), &LuaError::isErr);
     
     ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
     ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);

--- a/luaError.cpp
+++ b/luaError.cpp
@@ -1,11 +1,36 @@
 #include "luaError.h"
 
+void LuaError::_bind_methods(){
+    // Binding static GD methods. This allows the use of LuaError.new_error instead of neededing to call LuaError.new and than calling .setInfo
+    ClassDB::bind_static_method("LuaError", D_METHOD("new_err", "Message", "Type"), &LuaError::newErr, DEFVAL(LuaError::ERR_RUNTIME));
+    ClassDB::bind_static_method("LuaError", D_METHOD("err_none"), &LuaError::errNone);
+    ClassDB::bind_static_method("LuaError", D_METHOD("is_err", "var"), &LuaError::isErr);
+    
+    ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
+    ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);
+    ClassDB::bind_method(D_METHOD("set_type","Type"), &LuaError::setType);
+    ClassDB::bind_method(D_METHOD("get_type"), &LuaError::getType);
+    
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type");
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "msg"), "set_msg", "get_msg");
+
+    BIND_ENUM_CONSTANT(ERR_NONE);
+    BIND_ENUM_CONSTANT(ERR_TYPE);
+    BIND_ENUM_CONSTANT(ERR_RUNTIME);
+    BIND_ENUM_CONSTANT(ERR_SYNTAX);
+    BIND_ENUM_CONSTANT(ERR_MEMORY);
+    BIND_ENUM_CONSTANT(ERR_ERR);
+    BIND_ENUM_CONSTANT(ERR_FILE);
+}
+
+// Create a new error
 LuaError* LuaError::newErr(String msg, ErrorType type) {
     LuaError* err = memnew(LuaError);
     err->setInfo(msg, static_cast<LuaError::ErrorType>(type));
     return err;
 }
 
+// Create a new non error
 LuaError* LuaError::errNone() {
     LuaError* err = memnew(LuaError);
     err->setInfo("", ErrorType::ERR_NONE);
@@ -30,19 +55,19 @@ void LuaError::setInfo(String msg, ErrorType type) {
     errMsg = msg;
 }
 
-LuaError::operator String() const {
-    return errMsg;
-}
-
 bool LuaError::operator==(const ErrorType type) {
     return errType == type;
+}
+
+bool LuaError::operator==(const LuaError err) {
+    return errType == err.getType();
 }
 
 void LuaError::setMsg(String msg) {
     errMsg = msg;
 }
 
-String LuaError::getMsg() {
+String LuaError::getMsg() const {
     return errMsg;
 }
 
@@ -50,29 +75,6 @@ void LuaError::setType(ErrorType type) {
     errType = type;
 }
 
-LuaError::ErrorType LuaError::getType() {
+LuaError::ErrorType LuaError::getType() const {
     return errType;
-}
-
-void LuaError::_bind_methods(){
-    ClassDB::bind_static_method("LuaError", D_METHOD("new_err", "Message", "Type"), &LuaError::newErr);
-    ClassDB::bind_static_method("LuaError", D_METHOD("err_none"), &LuaError::errNone);
-    ClassDB::bind_static_method("LuaError", D_METHOD("is_err", "var"), &LuaError::isErr);
-    
-    ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
-    ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);
-    ClassDB::bind_method(D_METHOD("set_type","Type"), &LuaError::setType);
-    ClassDB::bind_method(D_METHOD("get_type"), &LuaError::getType);
-    
-
-    ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type");
-    ADD_PROPERTY(PropertyInfo(Variant::STRING, "msg"), "set_msg", "get_msg");
-
-    BIND_ENUM_CONSTANT(ERR_NONE);
-    BIND_ENUM_CONSTANT(ERR_TYPE);
-    BIND_ENUM_CONSTANT(ERR_RUNTIME);
-    BIND_ENUM_CONSTANT(ERR_SYNTAX);
-    BIND_ENUM_CONSTANT(ERR_MEMORY);
-    BIND_ENUM_CONSTANT(ERR_ERR);
-    BIND_ENUM_CONSTANT(ERR_FILE);
 }

--- a/luaError.cpp
+++ b/luaError.cpp
@@ -55,10 +55,10 @@ LuaError::ErrorType LuaError::getType() {
 }
 
 void LuaError::_bind_methods(){
-    ClassDB::bind_static_method("LuaError", D_METHOD("new_err", "Message", "Type"), &LuaError::newError);
+    ClassDB::bind_static_method("LuaError", D_METHOD("new_error", "Message", "Type"), &LuaError::newError);
     ClassDB::bind_static_method("LuaError", D_METHOD("error_none"), &LuaError::errNone);
     ClassDB::bind_static_method("LuaError", D_METHOD("is_error", "var"), &LuaError::isErr);
-
+    
     ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
     ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);
     ClassDB::bind_method(D_METHOD("set_type","Type"), &LuaError::setType);

--- a/luaError.cpp
+++ b/luaError.cpp
@@ -1,0 +1,61 @@
+#include "luaError.h"
+
+LuaError* LuaError::newError(String msg, ErrorType type) {
+    LuaError* err = memnew(LuaError);
+    err->setInfo(msg, static_cast<LuaError::ErrorType>(type));
+    return err;
+}
+
+LuaError* LuaError::errNone() {
+    LuaError* err = memnew(LuaError);
+    err->setInfo("", ErrorType::ERR_NONE);
+    return err;
+}
+
+void LuaError::setInfo(String msg, ErrorType type) {
+    errType = type;
+    errMsg = msg;
+}
+
+LuaError::operator String() const {
+    return errMsg;
+}
+
+bool LuaError::operator==(const ErrorType type) {
+    return errType == type;
+}
+
+void LuaError::setMsg(String msg) {
+    errMsg = msg;
+}
+
+String LuaError::getMsg() {
+    return errMsg;
+}
+
+void LuaError::setType(ErrorType type) {
+    errType = type;
+}
+
+LuaError::ErrorType LuaError::getType() {
+    return errType;
+}
+
+void LuaError::_bind_methods(){
+    ClassDB::bind_static_method("LuaError", D_METHOD("new_error", "Message", "Type"), &LuaError::newError);
+    ClassDB::bind_method(D_METHOD("set_msg","Message"), &LuaError::setMsg);
+    ClassDB::bind_method(D_METHOD("get_msg"), &LuaError::getMsg);
+    ClassDB::bind_method(D_METHOD("set_type","Type"), &LuaError::setType);
+    ClassDB::bind_method(D_METHOD("get_type"), &LuaError::getType);
+
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type");
+    ADD_PROPERTY(PropertyInfo(Variant::STRING, "msg"), "set_msg", "get_msg");
+
+    BIND_ENUM_CONSTANT(ERR_NONE);
+    BIND_ENUM_CONSTANT(ERR_TYPE);
+    BIND_ENUM_CONSTANT(ERR_RUNTIME);
+    BIND_ENUM_CONSTANT(ERR_SYNTAX);
+    BIND_ENUM_CONSTANT(ERR_MEMORY);
+    BIND_ENUM_CONSTANT(ERR_ERR);
+    BIND_ENUM_CONSTANT(ERR_FILE);
+}

--- a/luaError.h
+++ b/luaError.h
@@ -23,6 +23,7 @@ class LuaError : public RefCounted {
         };
         static LuaError* newError(String msg, ErrorType type);
         static LuaError* errNone();
+        static bool isErr(Variant var);
 
         void setInfo(String msg, ErrorType type);
         operator String() const;

--- a/luaError.h
+++ b/luaError.h
@@ -26,14 +26,13 @@ class LuaError : public RefCounted {
         static bool isErr(Variant var);
 
         void setInfo(String msg, ErrorType type);
-        operator String() const;
         bool operator==(const ErrorType type);
+        bool operator==(const LuaError err);
 
         void setMsg(String msg);
-        String getMsg();
+        String getMsg() const;
         void setType(ErrorType type);
-        ErrorType getType();
-        int getLineNumber();
+        ErrorType getType() const;
 
     private:
         ErrorType errType;

--- a/luaError.h
+++ b/luaError.h
@@ -21,7 +21,7 @@ class LuaError : public RefCounted {
             ERR_ERR     = LUA_ERRERR,
             ERR_FILE    = LUA_ERRFILE,
         };
-        static LuaError* newError(String msg, ErrorType type);
+        static LuaError* newErr(String msg, ErrorType type);
         static LuaError* errNone();
         static bool isErr(Variant var);
 

--- a/luaError.h
+++ b/luaError.h
@@ -1,0 +1,44 @@
+#ifndef LUAERROR_H
+#define LUAERROR_H
+
+#include "core/object/ref_counted.h"
+#include "core/core_bind.h"
+#include "luasrc/lua.hpp"
+
+class LuaError : public RefCounted {
+    GDCLASS(LuaError, RefCounted);
+
+    protected:
+        static void _bind_methods();
+
+    public:
+        enum ErrorType{
+            ERR_NONE    = 0,
+            ERR_TYPE    = 1,
+            ERR_RUNTIME = LUA_ERRRUN,
+            ERR_SYNTAX  = LUA_ERRSYNTAX,
+            ERR_MEMORY  = LUA_ERRMEM,
+            ERR_ERR     = LUA_ERRERR,
+            ERR_FILE    = LUA_ERRFILE,
+        };
+        static LuaError* newError(String msg, ErrorType type);
+        static LuaError* errNone();
+
+        void setInfo(String msg, ErrorType type);
+        operator String() const;
+        bool operator==(const ErrorType type);
+
+        void setMsg(String msg);
+        String getMsg();
+        void setType(ErrorType type);
+        ErrorType getType();
+        int getLineNumber();
+
+    private:
+        ErrorType errType;
+        String errMsg;
+};
+
+VARIANT_ENUM_CAST(LuaError::ErrorType)
+
+#endif

--- a/luaThread.cpp
+++ b/luaThread.cpp
@@ -1,0 +1,121 @@
+#include "luaThread.h"
+#include "lua.h"
+#include "luaCallable.h"
+
+void LuaThread::_bind_methods() {
+    ClassDB::bind_static_method("LuaThread", D_METHOD("new_thread", "lua"), &LuaThread::newThread);
+    
+    ClassDB::bind_method(D_METHOD("bind", "lua"), &LuaThread::bind);
+    ClassDB::bind_method(D_METHOD("resume"), &LuaThread::resume);
+    ClassDB::bind_method(D_METHOD("load_string"), &LuaThread::loadString);
+    ClassDB::bind_method(D_METHOD("load_file"), &LuaThread::loadFile);
+    ClassDB::bind_method(D_METHOD("is_done"), &LuaThread::isDone);
+
+}
+
+LuaThread* LuaThread::newThread(Ref<Lua> lua) {
+    LuaThread* thread = memnew(LuaThread);
+    thread->bind(lua);
+    return thread;
+}
+
+// binds the thread to a lua object
+void LuaThread::bind(Ref<Lua> lua) {
+    this->lua = lua;
+    parentState = lua->getState();
+    state = lua->newThread();
+    // register the yield method
+    lua_register(state, "yield", luaYield);
+}
+
+// loads a string into the threads state
+void LuaThread::loadString(String code) {
+    done = false;
+    luaL_loadstring(state, code.ascii().get_data());
+}
+
+
+LuaError* LuaThread::loadFile(String fileName) {
+    done = false;
+    Error error;
+    Ref<FileAccess> file = FileAccess::open(fileName, FileAccess::READ, &error);
+    if (error != Error::OK) {
+        return LuaError::newErr(vformat("error '%s' while opening file '%s'", error_names[error], fileName), LuaError::ERR_FILE);
+    }
+
+    String path = file->get_path_absolute();
+    int ret = luaL_loadfile(state, path.ascii().get_data());
+    if (ret != LUA_OK) {
+        return handleError(ret);
+    }
+    return LuaError::errNone();
+}
+
+// Value 1 will always be a boolean which indicates weather the thread is done or not.
+// If a error occures it will be value number 2, otherwise the rest of the values are arguments passed to yield()
+Variant LuaThread::resume() {
+    if (done) {
+        return LuaError::newErr("Thread is done executing", LuaError::ERR_RUNTIME);
+    }
+
+    int argc;
+    int ret = lua_resume(state, NULL, 0, &argc);
+    if (ret == LUA_OK) done = true; // thread is finished
+    else if (ret != LUA_YIELD) {
+        done = true;
+        return handleError(ret);
+    }
+    
+    Array toReturn;
+    for (int i = 1; i <= argc; i++) {
+        toReturn.append(lua->getVariant(i, state));
+    }
+
+    return toReturn;
+}
+
+bool LuaThread::isDone() {
+    return done;
+}
+
+LuaError* LuaThread::handleError(int lua_error) const {
+    String msg;
+    switch(lua_error) {
+        case LUA_ERRRUN: {
+            msg += "[LUA_ERRRUN - runtime error ]\n";
+            luaL_traceback(parentState, state, lua_tostring(state, -1), 2);
+            msg += lua_tostring(state, -1);
+            msg += "\n";
+            lua_pop(state, 1);
+            break;
+        }
+        case LUA_ERRSYNTAX:{
+            msg += "[LUA_ERRSYNTAX - syntax error ]\n";
+            luaL_traceback(parentState, state, lua_tostring(state, -1), 2);
+            msg += lua_tostring(state, -1);
+            msg += "\n";
+            lua_pop(state, 1);
+            break;
+        }
+        case LUA_ERRMEM:{
+            msg += "[LUA_ERRMEM - memory allocation error ]\n";
+            break;
+        }
+        case LUA_ERRERR:{
+            msg += "[LUA_ERRERR - error while handling another error]\n";
+            break;
+        }
+        case LUA_ERRFILE:{
+            msg += "[LUA_ERRFILE - error while opening file]\n";
+            break;
+        }
+        default: break;
+    }
+    
+    return LuaError::newErr(msg, static_cast<LuaError::ErrorType>(lua_error));
+}
+
+int LuaThread::luaYield(lua_State *state) {
+    int argc = lua_gettop(state);
+    return lua_yield(state, argc);
+}

--- a/luaThread.cpp
+++ b/luaThread.cpp
@@ -21,9 +21,12 @@ LuaThread* LuaThread::newThread(Ref<Lua> lua) {
 
 // binds the thread to a lua object
 void LuaThread::bind(Ref<Lua> lua) {
-    this->lua = lua;
     parentState = lua->getState();
     state = lua->newThread();
+    
+    // Updating the internal object to be this
+    lua_pushstring(state, "__OBJECT");
+	lua_pushlightuserdata(state, this);
     // register the yield method
     lua_register(state, "yield", luaYield);
 }
@@ -68,7 +71,7 @@ Variant LuaThread::resume() {
     
     Array toReturn;
     for (int i = 1; i <= argc; i++) {
-        toReturn.append(lua->getVariant(i, state));
+        toReturn.append(Lua::getVariant(i, state, Ref<RefCounted>(this)));
     }
 
     return toReturn;

--- a/luaThread.h
+++ b/luaThread.h
@@ -33,7 +33,6 @@ class LuaThread : public RefCounted {
         lua_State* state;
         lua_State* parentState;
         LuaError* handleError(int lua_error) const;
-        Ref<Lua> lua;
         bool done;
 
 };

--- a/luaThread.h
+++ b/luaThread.h
@@ -1,0 +1,41 @@
+#ifndef LUATHREAD_H
+#define LUATHREAD_H
+
+#include "luaError.h"
+
+#include "luasrc/lua.hpp"
+
+#include "core/object/ref_counted.h"
+#include "core/core_bind.h"
+#include "luasrc/lua.hpp"
+
+class Lua;
+
+class LuaThread : public RefCounted {
+    GDCLASS(LuaThread, RefCounted);
+
+    protected:
+        static void _bind_methods();
+
+    public:
+        static LuaThread* newThread(Ref<Lua> lua);
+
+        void bind(Ref<Lua> lua);
+        void loadString(String code);
+
+        LuaError* loadFile(String fileName);
+        Variant resume();
+        bool isDone();
+        
+        static int luaYield(lua_State *state);
+
+    private:
+        lua_State* state;
+        lua_State* parentState;
+        LuaError* handleError(int lua_error) const;
+        Ref<Lua> lua;
+        bool done;
+
+};
+
+#endif

--- a/luasrc/lauxlib.c
+++ b/luasrc/lauxlib.c
@@ -1102,4 +1102,3 @@ LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver, size_t sz) {
     luaL_error(L, "version mismatch: app. needs %f, Lua core provides %f",
                   (LUAI_UACNUMBER)ver, (LUAI_UACNUMBER)v);
 }
-

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,10 +1,13 @@
 #include "register_types.h"
 #include "lua.h"
 #include "luaError.h"
+#include "luaThread.h"
+#include "luaCallable.h"
 
 void initialize_lua_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		ClassDB::register_class<Lua>();
+		ClassDB::register_class<LuaThread>();
 		ClassDB::register_class<LuaError>();
 	}
 }

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,9 +1,11 @@
 #include "register_types.h"
 #include "lua.h"
+#include "luaError.h"
 
 void initialize_lua_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		ClassDB::register_class<Lua>();
+		ClassDB::register_class<LuaError>();
 	}
 }
 


### PR DESCRIPTION
This PR changes quite a bit and adds a lot of new features.
# Error Handling rework:
A new type was created that inherits RefCounted called LuaError. This type stores 2 properties:
- msg: Contains the error message.
- type: Contains the error type.

The error type is a enumeration with the following possible values:
- ERR_NONE: Indicates no error.
- ERR_TYPE: Indicates a error with argument types.
- ERR_RUNTIME: Indicates a generic runtime error.
- ERR_SYNTAX: Indicates a syntax error.
- ERR_MEMORY: Indicates a memory error.
- ERR_ERR: Indicates a error with the internal error handler. Should be reported.
- ERR_FILE: Indicates a error while opening a file.

This type is now returned by any function that can run into a error. Additionally, gd functions expose to lua can return this type to raise a error in the lua state.

Due to limitations in godot we are not able to take arguments in the Objects constructor. Instead LuaError has a static method called new_err. This takes in the error msg and type. This allows you to create a error without needing to call new() and bind().

Another static method is LuaError.is_err(var) this will return true if the Variants type is a LuaError and the Errors type is not ERR_NONE.

# Coroutines or LuaThread
Internally lua calls this a thread despite it being nothing like a OS thread. This module follows suite. 
A new type was created that inherits RefCounted called LuaThread.

LuaThreads bind to existing Lua objects. all threads bound to the same Lua object will share resources.
Much like the LuaError type we run into the same issue with constructors. Thus a static method exists LuaThread.new_thread(Lua). all this does is call LuaThread.new() and thred.bind(lua).

The threads state has 1 more exposed function from C than a normal Lua state. That being yield.
when lua calls yield any value will be packed into a array and returned by thread.resume()

All execution with LuaThread takes place on the main thread unless thread.resume() is called in a thread. Example usage:
```gdscript
extends Node2D
var lua: Lua
var thread: LuaThread
	
func _ready():
	lua = Lua.new()
	# Despite the name this is not like a OS thread. It is a coroutine
	thread = LuaThread.new_thread(lua)
	thread.load_string("
	while true do
		-- yield is exposed to lua when the thread is bound.
		yield(1)
		print('Hello world!')
	end
	")
	
var yieldTime = 0
var timeSince = 0;
func _process(delta):
	timeSince += delta
	if thread.is_done() || timeSince <= yieldTime:
		return
	# thread.resume will either return a LuaError or a Array.
	var results = thread.resume()
	if LuaError.is_err(results):
		print("ERROR %d: " % results.type + results.msg)
		return
	yieldTime = results[0]
	timeSince = 0
```

# Object metamethod overrides
Objects can now override most meta methods found [here](http://lua-users.org/wiki/MetatableEvents).
To do so you simply create a function with the same name that takes the correct arguments. 
Example:
```gdscript
extends Node2D
var lua: Lua
class Player:
	var pos = Vector2(1, 0)
	# Most metamethods can be overriden. The function names are the same as the metamethods.
	func __index(index):
		if index=="pos":
			return pos
		else:
			return LuaError.new_err("Invalid index '%s'" % index)
	func move_forward():
		pos.x+=1

func _ready():
	lua = Lua.new()
	lua.expose_constructor(Player, "Player")
	var err = lua.do_string("player = Player() print(player.pos.x)  player.move_forward() -- this will cause our custom error ")
	if LuaError.is_err(err):
		print(err.msg)
	var player = lua.pull_variant("player")
	print(player.pos)
```

 