### PR TITLE
Making loadlibraries work on Mac

### DIFF
--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -44,18 +44,20 @@ void LuaState::setState(lua_State *state, LuaAPI *api, bool bindAPI) {
 lua_State *LuaState::getState() const {
 	return L;
 }
+#include <iostream>
 
 // Binds lua libraries with the lua state
-Ref<LuaError> LuaState::bindLibraries(TypedArray<String> libs) {
-	for (int i = 0; i < libs.size(); i++) {
-		if (!loadLuaLibrary(L, libs[i])) {
-			return LuaError::newError(vformat("Library \"%s\" does not exist.", libs[i]), LuaError::ERR_RUNTIME);
-		}
-		if (libs[i] == "base") {
-			lua_register(L, "print", luaPrint);
-		}
-	}
-	return nullptr;
+Ref<LuaError> LuaState::bindLibraries(Array libs) {
+    for (int i = 0; i < libs.size(); i++) {
+        if (!loadLuaLibrary(L, libs[i])) {
+            return LuaError::newError(vformat("Library \"%s\" does not exist.", libs[i]), LuaError::ERR_RUNTIME);
+        }
+        if (libs[i] == String("base") ) {
+            lua_register(L, "print", luaPrint);
+        }
+    }
+    
+    return nullptr;
 }
 
 void LuaState::setHook(Callable hook, int mask, int count) {

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -56,7 +56,6 @@ Ref<LuaError> LuaState::bindLibraries(Array libs) {
             lua_register(L, "print", luaPrint);
         }
     }
-    
     return nullptr;
 }
 

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -48,15 +48,16 @@ lua_State *LuaState::getState() const {
 
 // Binds lua libraries with the lua state
 Ref<LuaError> LuaState::bindLibraries(Array libs) {
-    for (int i = 0; i < libs.size(); i++) {
-        if (!loadLuaLibrary(L, libs[i])) {
-            return LuaError::newError(vformat("Library \"%s\" does not exist.", libs[i]), LuaError::ERR_RUNTIME);
-        }
-        if (libs[i] == String("base") ) {
-            lua_register(L, "print", luaPrint);
-        }
-    }
-    return nullptr;
+	for (int i = 0; i < libs.size(); i++) {
+		if (!loadLuaLibrary(L, libs[i])) {
+			return LuaError::newError(vformat("Library \"%s\" does not exist.", libs[i]), LuaError::ERR_RUNTIME);
+		}
+		if (libs[i] == String("base") ) {
+			lua_register(L, "print", luaPrint);
+		}
+	}
+	
+	return nullptr;
 }
 
 void LuaState::setHook(Callable hook, int mask, int count) {

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -52,11 +52,11 @@ Ref<LuaError> LuaState::bindLibraries(Array libs) {
 		if (!loadLuaLibrary(L, libs[i])) {
 			return LuaError::newError(vformat("Library \"%s\" does not exist.", libs[i]), LuaError::ERR_RUNTIME);
 		}
-		if (libs[i] == String("base") ) {
+		if (libs[i] == String("base")) {
 			lua_register(L, "print", luaPrint);
 		}
 	}
-	
+
 	return nullptr;
 }
 

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -33,7 +33,7 @@ public:
 	Variant getRegistryValue(String name);
 
 	Ref<LuaError> setRegistryValue(String name, Variant var);
-	Ref<LuaError> bindLibraries(TypedArray<String> libs);
+	Ref<LuaError> bindLibraries(Array libs);
 	Ref<LuaError> pushVariant(Variant var) const;
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
 	Ref<LuaError> handleError(int lua_error) const;


### PR DESCRIPTION
Converting Godot String to const char* is having strange issues on Mac. So while that is tracked down, this change allows the Lua libraries to load by changing the implantation to no longer require the conversion of Godot String's to char* 