### PR TITLE
Fix build for newer godot versions on non MSVC

### DIFF
--- a/external/SCsub
+++ b/external/SCsub
@@ -26,7 +26,7 @@ elif luaver == "5.1":
         env_lua.Append(CPPDEFINES=['LUA_USE_IOS'])
 
     if not env_lua.msvc:
-        env_lua['CFLAGS'].remove('-std=gnu11')
+        env_lua['CFLAGS'].remove('-std=gnu17')
         env_lua.Append(CFLAGS=['-std=c99'])
 
     env_lua.Append(CPPPATH=[Dir('lua51').abspath])
@@ -41,7 +41,7 @@ else:
         env_lua.Append(CPPDEFINES=['LUA_USE_IOS'])
 
     if not env_lua.msvc:
-        env_lua['CFLAGS'].remove('-std=gnu11')
+        env_lua['CFLAGS'].remove('-std=gnu17')
         env_lua.Append(CFLAGS=['-std=c99'])
 
     env_lua.Append(CPPPATH=[Dir('lua').abspath])


### PR DESCRIPTION
Newer godot builds uses gnu17 instead of gnu11, this updates the flag removal to gnu17 instead of gnu11, fixing build on non msvc (like unix systems).